### PR TITLE
fix: Allow chat room fetching with invite code

### DIFF
--- a/internal/handlers/chatroom_handler.go
+++ b/internal/handlers/chatroom_handler.go
@@ -109,15 +109,19 @@ func (h *ChatRoomHandler) GetByIDHandler(c *gin.Context) {
 
 	inviteCode := c.Query("code")
 	if inviteCode != "" {
-		_, err = h.chatroomService.GetByInviteCode(inviteCode)
-		if err != nil {
-			if errors.Is(err, services.ErrChatRoomNotFound) {
-				c.JSON(http.StatusNotFound, utils.NewErrorResponse("Chat room not found"))
-			} else {
-				c.JSON(http.StatusInternalServerError, utils.NewErrorResponse("Failed to get chat room"))
-			}
-			return
-		}
+	    inviteRoom, err := h.chatroomService.GetByInviteCode(inviteCode)
+	    if err != nil {
+	        if errors.Is(err, services.ErrChatRoomNotFound) {
+	            c.JSON(http.StatusNotFound, utils.NewErrorResponse("Chat room not found"))
+	        } else {
+	            c.JSON(http.StatusInternalServerError, utils.NewErrorResponse("Failed to get chat room"))
+	        }
+	        return
+	    }
+	    if inviteRoom.ID != id {
+	        c.JSON(http.StatusBadRequest, utils.NewErrorResponse("Invalid invite code for this chat room"))
+	        return
+	    }
 	}
 
 	if !slices.Contains(getParticipantIDs(chatroom.Participants), userID.(string)) &&

--- a/internal/handlers/chatroom_handler.go
+++ b/internal/handlers/chatroom_handler.go
@@ -107,7 +107,21 @@ func (h *ChatRoomHandler) GetByIDHandler(c *gin.Context) {
 		return
 	}
 
-	if !slices.Contains(getParticipantIDs(chatroom.Participants), userID.(string)) {
+	inviteCode := c.Query("code")
+	if inviteCode != "" {
+		_, err = h.chatroomService.GetByInviteCode(inviteCode)
+		if err != nil {
+			if errors.Is(err, services.ErrChatRoomNotFound) {
+				c.JSON(http.StatusNotFound, utils.NewErrorResponse("Chat room not found"))
+			} else {
+				c.JSON(http.StatusInternalServerError, utils.NewErrorResponse("Failed to get chat room"))
+			}
+			return
+		}
+	}
+
+	if !slices.Contains(getParticipantIDs(chatroom.Participants), userID.(string)) &&
+		inviteCode == "" {
 		c.JSON(http.StatusForbidden, utils.NewErrorResponse("User not in chat room"))
 		return
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now join chat rooms using a valid invite code, even if they’re not pre-listed as participants.

- **Bug Fixes**
  - Enhanced error handling provides more specific feedback for invalid or missing invite codes, including 404 and 403 responses based on the context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->