### PR TITLE
feat: Add pagination to chat room messages

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -387,8 +387,14 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Number of messages to return (default 25)",
-                        "name": "count",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of messages per page (default 25)",
+                        "name": "page_size",
                         "in": "query"
                     }
                 ],
@@ -398,7 +404,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/utils.SuccessResponse"
+                                    "$ref": "#/definitions/utils.Pagination"
                                 },
                                 {
                                     "type": "object",
@@ -697,6 +703,28 @@ const docTemplate = `{
                 "success": {
                     "type": "boolean",
                     "example": false
+                }
+            }
+        },
+        "utils.Pagination": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "page": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "page_size": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "total_pages": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "total_rows": {
+                    "type": "integer",
+                    "example": 100
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -380,8 +380,14 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Number of messages to return (default 25)",
-                        "name": "count",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of messages per page (default 25)",
+                        "name": "page_size",
                         "in": "query"
                     }
                 ],
@@ -391,7 +397,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/utils.SuccessResponse"
+                                    "$ref": "#/definitions/utils.Pagination"
                                 },
                                 {
                                     "type": "object",
@@ -690,6 +696,28 @@
                 "success": {
                     "type": "boolean",
                     "example": false
+                }
+            }
+        },
+        "utils.Pagination": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "page": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "page_size": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "total_pages": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "total_rows": {
+                    "type": "integer",
+                    "example": 100
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -77,6 +77,22 @@ definitions:
         example: false
         type: boolean
     type: object
+  utils.Pagination:
+    properties:
+      data: {}
+      page:
+        example: 1
+        type: integer
+      page_size:
+        example: 10
+        type: integer
+      total_pages:
+        example: 10
+        type: integer
+      total_rows:
+        example: 100
+        type: integer
+    type: object
   utils.SuccessResponse:
     properties:
       data: {}
@@ -327,9 +343,13 @@ paths:
         name: id
         required: true
         type: integer
-      - description: Number of messages to return (default 25)
+      - description: Page number (default 1)
         in: query
-        name: count
+        name: page
+        type: integer
+      - description: Number of messages per page (default 25)
+        in: query
+        name: page_size
         type: integer
       produces:
       - application/json
@@ -338,7 +358,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/utils.SuccessResponse'
+            - $ref: '#/definitions/utils.Pagination'
             - properties:
                 data:
                   items:

--- a/internal/repositories/message_repository.go
+++ b/internal/repositories/message_repository.go
@@ -18,11 +18,18 @@ func (r *MessageRepository) Create(message *models.Message) error {
 	return r.db.Create(message).Error
 }
 
-func (r *MessageRepository) GetByRoomID(roomID uint, limit int) ([]models.Message, error) {
+func (r *MessageRepository) GetByRoomID(roomID uint, limit, offset int) ([]models.Message, error) {
 	var messages []models.Message
 	err := r.db.Where("room_id = ?", roomID).
 		Order("created_at desc").
 		Limit(limit).
+		Offset(offset).
 		Find(&messages).Error
 	return messages, err
+}
+
+func (r *MessageRepository) GetCountByRoomID(roomID uint) (int, error) {
+	var count int64
+	err := r.db.Model(&models.Message{}).Where("room_id = ?", roomID).Count(&count).Error
+	return int(count), err
 }

--- a/internal/services/message_service.go
+++ b/internal/services/message_service.go
@@ -17,6 +17,13 @@ func (s *MessageService) CreateMessage(message *models.Message) error {
 	return s.messageRepo.Create(message)
 }
 
-func (s *MessageService) GetMessagesByRoomID(roomID uint, limit int) ([]models.Message, error) {
-	return s.messageRepo.GetByRoomID(roomID, limit)
+func (s *MessageService) GetMessagesByRoomID(
+	roomID uint,
+	limit, offset int,
+) ([]models.Message, error) {
+	return s.messageRepo.GetByRoomID(roomID, limit, offset)
+}
+
+func (s *MessageService) GetCountByRoomID(roomID uint) (int, error) {
+	return s.messageRepo.GetCountByRoomID(roomID)
 }

--- a/internal/utils/responses.go
+++ b/internal/utils/responses.go
@@ -1,8 +1,8 @@
 package utils
 
 type SuccessResponse struct {
-	Success bool        `json:"success" example:"true"`
-	Message string      `json:"message" example:"success"`
+	Success bool        `json:"success"        example:"true"`
+	Message string      `json:"message"        example:"success"`
 	Data    interface{} `json:"data,omitempty"`
 }
 
@@ -24,4 +24,12 @@ func NewErrorResponse(message string) ErrorResponse {
 		Success: false,
 		Message: message,
 	}
+}
+
+type Pagination struct {
+	Page       int `json:"page"        example:"1"`
+	PageSize   int `json:"page_size"   example:"10"`
+	TotalRows  int `json:"total_rows"  example:"100"`
+	TotalPages int `json:"total_pages" example:"10"`
+	Data       any `json:"data"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the chat messages endpoint to use pagination. Instead of a single count parameter, you now specify "page" (default 1) and "page_size" (default 25) for message retrieval.
  - API responses now include detailed pagination information such as current page, page size, total pages, and total records.

- **Documentation**
  - API reference materials and interactive specs have been updated to reflect the new pagination parameters and enhanced response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->